### PR TITLE
Fixed: package-lock.json gets its content from yarn.lock file

### DIFF
--- a/libs/common-build-utils/src/lib/generate-package-json/all-deps-calculator.ts
+++ b/libs/common-build-utils/src/lib/generate-package-json/all-deps-calculator.ts
@@ -114,7 +114,7 @@ export function doWritePackageJson(
     const rootPackageLockLockFilePath = `${appRootPath}/package-lock.json`;
     if (fileExists(rootPackageLockLockFilePath)) {
       const distPackageLockLockFilePath = `${projectOutputPath}/package-lock.json`;
-      copyFileSync(rootYarnLockFilePath, distPackageLockLockFilePath);
+      copyFileSync(rootPackageLockLockFilePath, distPackageLockLockFilePath);
     }
   }
 }


### PR DESCRIPTION
Fixed: package-lock.json gets its content from yarn.lock file